### PR TITLE
Update parts list.txt

### DIFF
--- a/Hardware/Accessories/ActionCam Mount/parts list.txt
+++ b/Hardware/Accessories/ActionCam Mount/parts list.txt
@@ -5,5 +5,5 @@ parts list
 
 OR
 
-1 small zip tie        70215K61
+1 small zip tie        6614K34
 


### PR DESCRIPTION
Corrected the part number for the required 8 inch 18 lb zip tie that fits in the Zip Tie version of the Action Camera mount.